### PR TITLE
Add redirect to an official page with open source projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,16 +1,1 @@
-title: SoftServe Open Source Projects
-description: Homepage of open source projects developed by SoftServe team
-sitename: SoftServe Open Source
-homeurl: http://www.softserveinc.com/
-header_image: /assets/img/banner.jpg
-sass:
-  sass_dir: /assets/_sass
-  style: :compressed
-collections:
-  - features
-exclude:
-  - Gemfile
-  - Gemfile.lock
-  - README.md
-  - LICENSE.txt
-  - CNAME
+theme: jekyll-theme-cayman

--- a/index.html
+++ b/index.html
@@ -1,13 +1,6 @@
----
-layout: default
-heading: SoftServe Team	
-subheading: Open Source @ <a href="http://www.github.com/SoftServeInc">github</a> 
----
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://opensource.softserveinc.com</title>
+<meta http-equiv="refresh" content="0; URL=https://opensource.softserveinc.com">
+<link rel="canonical" href="https://opensource.softserveinc.com">
 
-
-{% include header.html %}
-
-<div class="container">
-  {% include features.html %}
-  {% include footer.html %}
-</div>


### PR DESCRIPTION
Now we have a different website which can be used instead of this one